### PR TITLE
Allow unused arguments with underscore start

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ module.exports = {
       "max": 1
     }],
     "no-undef-init": "error",
+    "no-unused-vars": ["error", {"argsIgnorePattern": "^_"}],
     "no-use-before-define": ["error", "nofunc"],
     "no-var": "error",
     "nonblock-statement-body-position": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-skoach",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Recommended ESLint settings used in Skoach.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Matches elixir. Unused args can be useful for documentation.